### PR TITLE
Restore the default behavior of <C-e> and <C-y> in neoscroll.lua

### DIFF
--- a/.config/nvim/lua/yyossy/plugins/neoscroll.lua
+++ b/.config/nvim/lua/yyossy/plugins/neoscroll.lua
@@ -1,5 +1,11 @@
 -- https://github.com/karb94/neoscroll.nvim
 return {
   "karb94/neoscroll.nvim",
-  opts = {},
+  config = function(_, opts)
+    require("neoscroll").setup(opts)
+
+    -- Restore the default behavior of <C-e> and <C-y>
+    vim.keymap.set("n", "<C-e>", "", { noremap = true, silent = true }) -- Scroll down one line
+    vim.keymap.set("n", "<C-y>", "", { noremap = true, silent = true }) -- Scroll up one line
+  end,
 }


### PR DESCRIPTION
close https://github.com/teihenn/dotfiles/issues/95