### PR TITLE
相対行番号＋現在行のみ絶対行番号にする

### DIFF
--- a/nvim/lua/yyossy/core/options.lua
+++ b/nvim/lua/yyossy/core/options.lua
@@ -5,8 +5,9 @@ local opt = vim.opt -- for conciseness
 -- tips: you can use "h" command to know more about options like ":h autoindent"
 
 -- line numbers
-opt.relativenumber = false -- show relative line numbers
+opt.relativenumber = true -- show relative line numbers
 opt.number = true -- shows absolute line number on cursor line (when relative number is on)
+-- opt.statuscolumn = [[%!v:lnum . '│' . (v:lnum == line('.') ? '0' : abs(v:lnum - line('.')))]]
 
 -- tabs & indentation
 opt.tabstop = 2 -- 2 spaces for tabs (prettier default)

--- a/nvim/lua/yyossy/plugins/colorschema.lua
+++ b/nvim/lua/yyossy/plugins/colorschema.lua
@@ -125,6 +125,11 @@ return {
 
       -- setup must be called before loading
       vim.cmd("colorscheme nightfox")
+
+      -- Set the highlight for the current line number (absolute line number)
+      vim.cmd([[
+        highlight CursorLineNr guifg=#00ffff guibg=NONE gui=NONE
+      ]])
     end,
   },
   {


### PR DESCRIPTION
close https://github.com/teihenn/dotfiles/issues/32

以下のように現在行のみ絶対行番号にして、黄色じゃなくて水色になるようにした
![image](https://github.com/user-attachments/assets/24cbb2ba-4f23-4c89-a092-6badbf0159f5)
