### PR TITLE
Disable treesitter-context

### DIFF
--- a/nvim/lua/yyossy/plugins/lsp/treesitter-context.lua
+++ b/nvim/lua/yyossy/plugins/lsp/treesitter-context.lua
@@ -3,13 +3,14 @@ return {
   dependencies = { "nvim-treesitter/nvim-treesitter" },
   config = function()
     require("treesitter-context").setup({
-      enable = true, -- Enable the plugin
+      enable = false, -- Enable the plugin
       max_lines = 0, -- Maximum number of lines to show for context
       min_window_height = 0, -- Minimum editor window height to enable context
       line_numbers = true, -- Show line numbers in context window
-      multiline_threshold = 1000, -- Max number of lines for a single context block
+      multiline_threshold = 20, -- Max number of lines for a single context block
       trim_scope = "outer", -- Which scope to trim if context is too big
       mode = "topline", -- Show context for current cursor position
+      separator = "_",
     })
   end,
 }


### PR DESCRIPTION
close https://github.com/teihenn/dotfiles/issues/203

dropbar.nvimでもある程度現在のコンテキストはわかるし、
treesitter-contextはオプションをいじってもいまいち違和感の無い挙動にするのが難しかったので、
もうオフしてしまうことにした