### PR TITLE
Telescopeのlsp_referencesで検索欄にファイルパスのみを表示するよう設定を追加

### DIFF
--- a/nvim/lua/yyossy/plugins/telescope.lua
+++ b/nvim/lua/yyossy/plugins/telescope.lua
@@ -43,6 +43,23 @@ return {
             height = 0.8,
             preview_width = 0.45,
           },
+          path_display = { "absolute" },
+          entry_maker = function(entry)
+            local filename = entry.filename
+            local lnum = entry.lnum
+            local col = entry.col
+            local text = entry.text
+
+            return {
+              value = entry,
+              display = filename,
+              ordinal = filename .. " " .. text,
+              filename = filename,
+              lnum = lnum,
+              col = col,
+              text = text,
+            }
+          end,
         },
       },
     })


### PR DESCRIPTION
- path_display = { "absolute" }でフルパス表示を指定
- entry_makerでカスタム表示フォーマットを設定し、検索欄にファイルパスのみを表示

🤖 Generated with [Claude Code](https://claude.ai/code)


close https://github.com/yyossy5/dotfiles/issues/306