### PR TITLE
nvimのmarkdownのlintのindentをスペース4つにする

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 4,
+  "overrides": [
+    {
+      "files": "markdown",
+      "options": {
+        "tabWidth": 4
+      }
+    }
+  ]
+}


### PR DESCRIPTION
close #403 