### PR TITLE
Gemini CLI: migrate deprecated tools.exclude to Policy Engine

### DIFF
--- a/gemini/policies/tools.toml
+++ b/gemini/policies/tools.toml
@@ -1,0 +1,27 @@
+[[rule]]
+toolName = "run_shell_command"
+commandPrefix = [
+  "rm -rf",
+  "sudo dd",
+  "sudo mkfs",
+  "sudo fdisk",
+  "sudo mount",
+  "sudo umount",
+  "dd",
+  "mkfs",
+  "fdisk",
+  "chmod 777 /*",
+  "chown root",
+  "sudo chmod 777",
+  "sudo chown",
+  "sudo -i",
+  "sudo su",
+  "docker system prune -af",
+  "npm publish",
+  "cargo publish",
+  "git commit",
+  "git push"
+]
+decision = "deny"
+priority = 100
+denyMessage = "セキュリティ制限：このコマンドは Gemini CLI 経由での実行が禁止されています。"

--- a/gemini/policies/tools.toml
+++ b/gemini/policies/tools.toml
@@ -19,7 +19,6 @@ commandPrefix = [
   "docker system prune -af",
   "npm publish",
   "cargo publish",
-  "git commit",
   "git push"
 ]
 decision = "deny"

--- a/gemini/settings.json
+++ b/gemini/settings.json
@@ -1,27 +1,5 @@
 {
   "tools": {
-    "exclude": [
-      "run_shell_command(rm -rf)",
-      "run_shell_command(sudo dd)",
-      "run_shell_command(sudo mkfs)",
-      "run_shell_command(sudo fdisk)",
-      "run_shell_command(sudo mount)",
-      "run_shell_command(sudo umount)",
-      "run_shell_command(dd)",
-      "run_shell_command(mkfs)",
-      "run_shell_command(fdisk)",
-      "run_shell_command(chmod 777 /*)",
-      "run_shell_command(chown root)",
-      "run_shell_command(sudo chmod 777)",
-      "run_shell_command(sudo chown)",
-      "run_shell_command(sudo -i)",
-      "run_shell_command(sudo su)",
-      "run_shell_command(docker system prune -af)",
-      "run_shell_command(npm publish)",
-      "run_shell_command(cargo publish)",
-      "run_shell_command(git commit)",
-      "run_shell_command(git push)"
-    ],
     "shell": {
       "showColor": true
     }

--- a/setup.sh
+++ b/setup.sh
@@ -185,6 +185,11 @@ install_gemini() {
     log "Linking Gemini agents directory..."
     backup_and_link "$HOME/.gemini/agents" "$DOTFILES_DIR/gemini/agents"
   fi
+
+  if [ -d "$DOTFILES_DIR/gemini/policies" ]; then
+    log "Linking Gemini policies directory..."
+    backup_and_link "$HOME/.gemini/policies" "$DOTFILES_DIR/gemini/policies"
+  fi
 }
 
 install_codex() {


### PR DESCRIPTION
close #434 