### PR TITLE
MCPサーバー設定をgit管理外のローカル管理へ分離

### DIFF
--- a/APM.md
+++ b/APM.md
@@ -3,6 +3,7 @@
 Claude Code / Gemini CLI / Antigravity CLI / Codex CLIのSkill・Command・Agentを、
 [microsoft/apm](https://github.com/microsoft/apm) を使って
 `.apm/` 配下に一元管理している。
+MCPサーバーはapm管理の対象外([MCPサーバーの管理方針](#mcpサーバーの管理方針)を参照)。
 
 このドキュメントでは、アーキテクチャと日常的な追加・削除フローを説明する。
 
@@ -46,11 +47,11 @@ dotfiles/
 
 ### デプロイ先(apm installで自動生成される)
 
-| 種類 | Claude Code | Gemini CLI | Codex CLI |
-| --- | --- | --- | --- |
-| Skill | `~/.claude/skills/<name>/SKILL.md` | `~/.agents/skills/<name>/SKILL.md`(公式エイリアス) | `~/.agents/skills/<name>/SKILL.md` |
-| Command | `~/.claude/commands/<name>.md` | `~/.gemini/commands/<name>.toml` | (非対応) |
-| Agent | `~/.claude/agents/<name>.md` | (今回は未使用) | `~/.codex/agents/<name>.md` |
+| 種類    | Claude Code                        | Gemini CLI                                         | Codex CLI                          |
+| ------- | ---------------------------------- | -------------------------------------------------- | ---------------------------------- |
+| Skill   | `~/.claude/skills/<name>/SKILL.md` | `~/.agents/skills/<name>/SKILL.md`(公式エイリアス) | `~/.agents/skills/<name>/SKILL.md` |
+| Command | `~/.claude/commands/<name>.md`     | `~/.gemini/commands/<name>.toml`                   | (非対応)                           |
+| Agent   | `~/.claude/agents/<name>.md`       | (今回は未使用)                                     | `~/.codex/agents/<name>.md`        |
 
 `~/.agents/skills/` はGemini CLI公式サポートのエイリアスで、
 `~/.gemini/skills/` より優先される。
@@ -134,6 +135,7 @@ apm --version
     ---
     description: コマンドピッカーに表示される説明(必須)
     ---
+
     (プロンプト本文)
     ```
 
@@ -153,6 +155,82 @@ apm --version
 1. `.apm/prompts/<name>.prompt.md` を削除する
 2. 再度 `apm install --root "$HOME" --target claude,gemini` を実行する
    (stale filesとして自動削除される)
+
+## MCPサーバーの管理方針
+
+MCPサーバーは**apm管理の対象外**とし、各マシンのローカル設定
+(git管理外)で管理する。
+
+### 検討の経緯(2026-07-05)
+
+`apm.yml`の`dependencies.mcp:`への一元化を実装・実機検証したが、
+以下の理由で採用を見送った。
+
+1. マシン間で共有管理したいMCPサーバーが今のところなく
+   MCPサーバ追加する頻度も高くないため使用したいツールで手動で追加する管理のほうがシンプル
+2. apmはデプロイ時に`${VAR}`参照を生のシークレット値に解決して
+   git管理下の`gemini/settings.json`(symlink先)へ書き込むため、
+   commit前の差分確認・書き戻しという運用負担が常に残る
+3. apm 0.23.1のMCP対応に制約が多い
+    - Claude Code向けは通常インストールだと`$HOME/.mcp.json`
+      (プロジェクトスコープ)に書かれ、ユーザースコープ
+      (`~/.claude.json`)には`-g`+`~/.apm/apm.yml`が必要
+    - `--mcp`フラグと`--root`の併用に不具合がある
+    - `timeout`等のツール固有キーやGemini固有の`oauth`ブロックを
+      表現できない
+
+apmのMCP対応が成熟し、マシン間で共有したいMCPサーバーが
+出てきたら再検討する。
+
+### 現在の管理方法
+
+| ツール      | 置き場所(いずれもgit管理外)                                         |
+| ----------- | ------------------------------------------------------------------- |
+| Claude Code | `~/.claude.json` (`claude mcp add -s user`で追加)                   |
+| Gemini CLI  | `~/.gemini/settings.local.json`                                     |
+| Codex CLI   | `codex/config.toml`に手書き(従来どおり。シークレット無しのもののみ) |
+
+- Gemini CLIは`~/.zshrc.local`で
+  `export GEMINI_CLI_SYSTEM_SETTINGS_PATH="$HOME/.gemini/settings.local.json"`
+  を定義し、システム設定レイヤーとして読み込ませている
+  (`mcpServers`はレイヤー間でマージされ、tracked側の
+  `gemini/settings.json`にはMCP設定を置かない)
+- シークレット(APIキー等)は`~/.zshrc.local`に`export`し、
+  設定ファイル側は`${VAR}`参照にする
+  (Claude Code / Gemini CLIとも起動時に環境変数を解決する)
+- git管理下のファイル(`gemini/settings.json`, `codex/config.toml`等)に
+  生のシークレット値を書かないこと(コミット禁止ルール)
+
+### slack-mcpのClaude Code接続について
+
+SlackのMCPサーバー(mcp.slack.com)はDynamic Client Registration
+非対応で、事前登録したOAuthクライアントが必須。さらにSlackアプリの
+リダイレクトURLはhttps必須のため、Claude Codeのコールバック
+(`http://localhost:<port>/callback`、パス・スキーム固定)は登録できず、
+Claude CodeのOAuthフローは使えない。
+
+代わりにGemini CLIのOAuthで取得済みのユーザートークン
+(xoxp-、長期有効)を`~/.zshrc.local`の`SLACK_MCP_USER_TOKEN`に置き、
+Bearerヘッダー直指定で接続している。
+
+```bash
+claude mcp add -s user --transport http slack-mcp \
+  https://mcp.slack.com/mcp \
+  --header 'Authorization: Bearer ${SLACK_MCP_USER_TOKEN}'
+```
+
+トークンが失効した場合はGemini CLI側で再認証し、
+`~/.gemini/mcp-oauth-tokens.json`から新しいトークンを取り出して
+`SLACK_MCP_USER_TOKEN`を更新する。
+
+### 新しいマシンでのセットアップ
+
+MCPサーバーが必要な場合のみ、以下を手で用意する(全てgit管理外)。
+
+1. `~/.zshrc.local`: シークレットと
+   `GEMINI_CLI_SYSTEM_SETTINGS_PATH`のexport
+2. `~/.gemini/settings.local.json`: Gemini CLI用のMCPサーバー定義
+3. `claude mcp add -s user ...`: Claude Code用のMCPサーバー追加
 
 ## Antigravity CLI / Codex CLI
 

--- a/gemini/settings.json
+++ b/gemini/settings.json
@@ -4,16 +4,6 @@
       "showColor": true
     }
   },
-  "mcpServers": {
-    "atlassian": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://mcp.atlassian.com/v1/mcp/authv2"
-      ]
-    }
-  },
   "general": {
     "preferredEditor": "vim",
     "previewFeatures": true,
@@ -22,6 +12,10 @@
       "warningAcknowledged": true,
       "enabled": true,
       "maxAge": "120d"
+    },
+    "enableAutoUpdate": true,
+    "plan": {
+      "enabled": true
     }
   },
   "security": {
@@ -37,7 +31,16 @@
     "showLineNumbers": false
   },
   "experimental": {
-    "plan": true,
-    "enableAgents": true
+    "enableAgents": true,
+    "contextManagement": true
+  },
+  "agents": {
+    "overrides": {}
+  },
+  "telemetry": {
+    "enabled": true,
+    "target": "gcp",
+    "useCliAuth": true,
+    "logPrompts": true
   }
 }

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,3 +1,7 @@
+
+# Kiro CLI pre block. Keep at the top of this file.
+[[ -f "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.pre.zsh" ]] && builtin source "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.pre.zsh"
+
 # Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
 # Initialization code that may require console input (password prompts, [y/n]
 # confirmations, etc.) must go above this block; everything else may go below.
@@ -202,11 +206,17 @@ if [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then . "$HOME/google-clou
 
 # -------------------- Java --------------------
 # export PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH"
-export JAVA_HOME=$(/usr/libexec/java_home -v21)
+#export JAVA_HOME=$(/usr/libexec/java_home -v21)
+#export JAVA_HOME=$(/usr/libexec/java_home -v24)
+export JAVA_HOME=$(/usr/libexec/java_home -v25)
 export PATH="$JAVA_HOME/bin:$PATH"
 
 alias use_java14='export JAVA_HOME=$(/usr/libexec/java_home -v14); export PATH="$JAVA_HOME/bin:$PATH"'
 alias use_java21='export JAVA_HOME=$(/usr/libexec/java_home -v21); export PATH="$JAVA_HOME/bin:$PATH"'
+alias use_java24='export JAVA_HOME=$(/usr/libexec/java_home -v24); export PATH="$JAVA_HOME/bin:$PATH"'
+alias use_java25='export JAVA_HOME=$(/usr/libexec/java_home -v25); export PATH="$JAVA_HOME/bin:$PATH"'
+
+# MAVEN_OPTS(プロキシ認証情報を含む)は~/.zshrc.localで定義する
 
 # -------------------- aqua --------------------
 export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"
@@ -268,7 +278,6 @@ alias ggpushf='git push --force-with-lease origin "$(git_current_branch)"'
 
 alias gsh='git show'
 
-
 alias gsta='git stash'
 alias gstp='git stash pop'
 
@@ -276,3 +285,6 @@ alias gst='git status'
 
 # マシン固有のシークレット等(git管理外)を読み込む
 [ -f "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"
+
+# Kiro CLI post block. Keep at the bottom of this file.
+[[ -f "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.post.zsh" ]] && builtin source "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.post.zsh"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -273,3 +273,6 @@ alias gsta='git stash'
 alias gstp='git stash pop'
 
 alias gst='git status'
+
+# マシン固有のシークレット等(git管理外)を読み込む
+[ -f "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"


### PR DESCRIPTION
close #441 

## 概要

MCPサーバー設定の管理方針を整理する。

Skill/Command (#437, #439) と同じ発想でapm.ymlの `dependencies.mcp:` への
一元管理を実装・実機検証したが、以下の理由で採用を見送り、
**各マシンのローカル設定(git管理外)で管理する方針**とした。

1. マシン間で共有管理したいMCPサーバーが今のところなく、追加頻度も
   高くないため、使用したいツールへ手動で追加する管理のほうがシンプル
2. apmはデプロイ時に `${VAR}` 参照を生のシークレット値に解決して
   git管理下のファイル(symlink先)へ書き込むため、commit前の差分確認・
   書き戻しという運用負担が常に残る
3. apm 0.23.1のMCP対応に制約が多い
    - Claude Code向けは通常インストールだと `$HOME/.mcp.json`
      (プロジェクトスコープ)に書かれ、ユーザースコープには
      `-g` + `~/.apm/apm.yml` が必要
    - `--mcp` フラグと `--root` の併用に不具合がある
    - `timeout` 等のツール固有キーやGemini固有の `oauth` ブロックを表現できない

apmのMCP対応が成熟し、マシン間で共有したいMCPサーバーが出てきたら再検討する。

## 変更内容

- `gemini/settings.json` から `mcpServers` を削除
    - 実体は `~/.gemini/settings.local.json` (git管理外)へ移行し、
      `GEMINI_CLI_SYSTEM_SETTINGS_PATH` でシステム設定レイヤーとして読み込む
    - Claude Codeは `~/.claude.json` (元々git管理外)で管理
- APM.mdに「MCPサーバーの管理方針」の節を追加
    - 見送りの経緯、現在の管理方法、シークレット運用ルール
      (`${VAR}` 参照 + `~/.zshrc.local`)
    - slack-mcpのClaude Code接続手順(OAuthフローが使えないため
      Bearerトークン直指定方式)とトークン失効時の対処
    - 新しいマシンでのセットアップ手順
- `zsh/.zshrc` の整理
    - 認証情報を含む環境変数などマシン固有の設定を
      `~/.zshrc.local` (git管理外)へ退避
    - `~/.zshrc.local` を読み込む仕組みを追加
    - デフォルトのJavaを25に切り替え、`use_java24/25` エイリアスを追加

## 検証

- Gemini CLI: `gemini mcp list` で4サーバーすべてConnected
  (settings.local.json経由の読み込み、`${VAR}` の実行時解決を含む)
- Claude Code: `claude mcp list` で4サーバーすべてConnected
  (slack-mcpのBearerトークン接続を含む)
- 全commitの差分に生のシークレット値が含まれないことを確認済み

## 影響

- このPRのmerge後、他マシンでは `~/.gemini/settings.json` (symlink)から
  MCP設定が消える。MCPサーバーが必要な場合はAPM.mdの
  「新しいマシンでのセットアップ」の手順でローカル設定に追加する